### PR TITLE
Track skip in AlarmSnoozeApplet.lua

### DIFF
--- a/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
+++ b/src/squeezeplay/share/applets/AlarmSnooze/AlarmSnoozeApplet.lua
@@ -714,7 +714,7 @@ function openAlarmWindow(self)
 
 	window:ignoreAllInputExcept(
 		--these actions are not ignored
-		{ 'go', 'back', 'power', 'mute', 'volume_up', 'volume_down', 'pause' }, 
+		{ 'go', 'back', 'power', 'mute', 'volume_up', 'volume_down', 'pause', 'jump_fwd', 'jump_rew' }, 
 		-- consumeAction is the callback issued for all "ignored" input
 		consumeAction 
 	)


### PR DESCRIPTION
Enable track skip forward and backward during alarm via device buttons and IR RC.